### PR TITLE
Add help command

### DIFF
--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -42,10 +42,33 @@ public class Ui {
             return addEvent(input);
         case "find":
             return itemList.findTask(Parser.getDescription(input));
+        case "/help":
+            return listCommands();
         // unrecognised commands
         default:
             throw new DukeException("OOPS!!! I'm sorry, but I don't know what that means :-(");
         }
+    }
+
+    public static String greetUser() {
+        String greeting = "Welcome to your personal assistant Duke! How may I help you today?";
+        return greeting + "\nFor more information about available commands, enter '/help' into the text box";
+    }
+
+    private String listCommands() {
+        String commands = "Here is a list of possible commands";
+        String addTaskCommands = "\n\tAdd tasks:" +
+                "\n1. todo DESCRIPTION" +
+                "\n2. deadline DESCRIPTION /by YYYY-MM-DD HH:mm" +
+                "\n3. event DESCRIPTION /by YYYY-MM-DD HH:mm-HH:mm";
+        String others = "\n\tOther functions include:" +
+                "\n4. mark TASK_INDEX" +
+                "\n5. unmark TASK_INDEX" +
+                "\n6. find TASK_INDEX" +
+                "\n7. delete TASK_INDEX" +
+                "\n7. list" +
+                "\n7. bye";
+        return commands + addTaskCommands + others;
     }
 
     private String addTodo(String input) throws DukeException {

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -1,5 +1,6 @@
 package duke.gui;
 
+import duke.Ui;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -36,6 +37,10 @@ public class MainWindow extends AnchorPane {
     @FXML
     public void initialize() {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
+        Label greeting = new Label(Ui.greetUser());
+        dialogContainer.getChildren().add(
+                DialogBox.getDukeDialog(greeting, new ImageView(dukeImage))
+        );
     }
 
     public void setDuke(Duke d) {

--- a/src/test/java/duke/DeadlineTest.java
+++ b/src/test/java/duke/DeadlineTest.java
@@ -7,12 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DeadlineTest {
     Deadline testEvent = new Deadline("lunch", "2022-02-03", "12:00");
     @Test
-    public void testToString() {
+    public void deadlineToString_correctStringFormat() {
         assertEquals(testEvent.toString(), "[D][ ] lunch (by: Feb 3 2022, 1200PM)");
     }
 
     @Test
-    public void testToFile(){
+    public void eventToFile_correctFileFormat(){
         assertEquals(testEvent.toFile(), "D|0|lunch|2022-02-03|12:00\n");
     }
 }

--- a/src/test/java/duke/EventTest.java
+++ b/src/test/java/duke/EventTest.java
@@ -7,12 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class EventTest {
     Event testEvent = new Event("lunch", "2022-02-03", "12:00", "14:00");
     @Test
-    public void testToString() {
+    public void eventToString_correctStringFormat() {
         assertEquals(testEvent.toString(), "[E][ ] lunch (at: Feb 3 2022, 1200PM to 0200PM)");
     }
 
     @Test
-    public void testToFile() {
+    public void eventToFile_correctFileFormat() {
         assertEquals(testEvent.toFile(), "E|0|lunch|2022-02-03|12:00|14:00\n");
     }
 }


### PR DESCRIPTION
There are many commands that can be used and each command requires the user to follow the specified input format precisely.

New users to the app need to be able to find out what commands are available and the specific ways to the details need to be typed in. Regular users might also forget certain commands. Hence a help command is required.

Let's add a help command to list out the possible inputs and their required input formats.

This allows users to quickly refer to it when needed while using Duke.